### PR TITLE
#41 自动测试搭建, 第一批四个用例

### DIFF
--- a/src/期望值表.py
+++ b/src/期望值表.py
@@ -1,0 +1,6 @@
+期望值 = {
+    "basic/assign.cantonese": "1\n3\n",
+    "basic/class.cantonese": "Duck is swimming\nDuck is sleeping\n公\n",
+    "basic/comment.cantonese": "Run OK\n",
+    "basic/HelloWorld.cantonese": " Hello World! \n",
+}

--- a/src/测试.py
+++ b/src/测试.py
@@ -1,0 +1,25 @@
+from 期望值表 import 期望值
+from 运行 import 运行代码
+from pathlib import Path
+import unittest
+
+# 在 src 下运行 `python -m unittest 测试.py`
+class test所有(unittest.TestCase):
+
+    def test(self):
+        测试目录 = '../examples/'
+        全部通过 = True
+        失败表 = {}
+
+        for 文件 in 期望值:
+            路径 = 测试目录 + 文件
+            实际值 = 运行代码(路径)
+            预期值 = 期望值[文件].encode('utf-8')
+
+            if 实际值 != 预期值:
+                失败表[文件] = 实际值
+                全部通过 = False
+
+        for 文件 in 失败表:
+            print(f"失败： {文件} 期望：{期望值[文件]} 实际：{失败表[文件]}")
+        self.assertTrue(全部通过, "以上用例未通过！")

--- a/src/运行.py
+++ b/src/运行.py
@@ -1,0 +1,13 @@
+import re, subprocess
+from pathlib import Path
+
+def 运行代码(源码文件):
+    源码文件 = str(Path(源码文件))
+    with open(源码文件, 'r', encoding='utf-8') as f:
+        源码 = f.read()
+
+    # 删去注释
+    源码 = re.sub(re.compile(r'/\*.*?\*/', re.S), ' ', 源码)
+
+    参数 = ["python", "cantonese.py", 源码文件]
+    return subprocess.Popen(参数, stdout=subprocess.PIPE).communicate()[0]


### PR DESCRIPTION
获取进程输出，与期望值作比较。
主要是搭起测试架子，后续可添加更多用例。
在 mac 测试通过：在 src 下运行 `python -m unittest 测试.py`。请在 windows 下测试看是否通过？